### PR TITLE
Define built web-features package in its own directory

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,8 +17,8 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - name: Pretty print built index.json
-        run: jq . index.json
+      - name: Pretty print built JSON
+        run: jq . packages/web-features/index.json
   test:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "web-features",
+  "name": "feature-set",
+  "private": true,
   "description": "Exploring the set of interoperable features in the Web Platform",
   "version": "0.1.0",
   "repository": {

--- a/packages/web-features/README.md
+++ b/packages/web-features/README.md
@@ -1,0 +1,13 @@
+# Curated list of Web platform features
+
+This package is experimental, expect frequent breaking changes!
+
+## Usage
+
+```sh
+npm install web-features
+```
+
+```js
+import webFeatures from 'web-features' assert { type: 'json' };
+```

--- a/packages/web-features/package.json
+++ b/packages/web-features/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "web-features",
+  "description": "Curated list of Web platform features",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/web-platform-dx/feature-set.git"
+  },
+  "main": "index.json"
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -7,7 +7,8 @@ import features from '../index.js';
 function build() {
     const json = stringify(features);
     // TODO: Validate the resulting JSON against a schema.
-    fs.writeFileSync('index.json', json);
+    const path = new URL('../packages/web-features/index.json', import.meta.url);
+    fs.writeFileSync(path, json);
 }
 
 build();


### PR DESCRIPTION
It needs its own package.json and README. Even if they can be derived by
scripts, it's still convenient to use this structure. It's similar to
webref, and also the structure that Lerna expects. But it's also
possible to just run `npm publish` from the subdirectory.
