### PR TITLE
Add Flintstoned simplified support status

### DIFF
--- a/feature-group-definitions/cascade-layers.yml
+++ b/feature-group-definitions/cascade-layers.yml
@@ -1,3 +1,11 @@
 spec: https://drafts.csswg.org/css-cascade-5/#layering
 caniuse: css-cascade-layers
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4007
+support_status:
+  baseline:
+    status: true
+    since: 2022-03-15
+    initial_versions:
+      chrome: "99"
+      firefox: "97"
+      safari: "15.4"

--- a/feature-group-definitions/container-queries.yml
+++ b/feature-group-definitions/container-queries.yml
@@ -1,3 +1,9 @@
 spec: https://drafts.csswg.org/css-contain-3/#container-queries
 caniuse: css-container-queries
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/4165
+support_status:
+  baseline:
+    status: false
+    initial_versions:
+      chrome: "105"
+      safari: "16"

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,13 @@ import YAML from 'yaml';
 interface FeatureData {
     spec: string,
     caniuse?: string
+    support_status_summary: SupportStatusSummary
+}
+
+type browserIdentifier = "chrome" | "firefox" | "safari";
+
+interface SupportStatusSummary {
+    baseline: { status: boolean, since?: string, initial_versions?: {[K in browserIdentifier]?: string} }
 }
 
 const filePaths = new fdir()

--- a/schemas/features.schema.json
+++ b/schemas/features.schema.json
@@ -10,6 +10,34 @@
       "type": "string",
       "description": "Feature usage metric URL",
       "format": "uri"
+    },
+    "baseline_status_report": {
+      "type": "object",
+      "description": "Whether a feature is considered a \"baseline\" web platform feature and when it achieved that status",
+      "properties": {
+        "status": {
+          "type": "boolean",
+          "description": "Whether the feature achieved baseline status"
+        },
+        "since": {
+          "type": "string",
+          "description": "When the feature achieved baseline status",
+          "format": "date"
+        },
+        "initial_versions": {
+          "type": "object",
+          "description": "Browser identifiers and the first version from which they had baseline status",
+          "patternProperties": {
+            "^[a-z][a-z_]+[a-z]": {
+              "type": "string"
+            } 
+          }
+        }
+      },
+      "required": [
+        "status"
+      ],
+      "additionalProperties": false
     }
   },
   "type": "object",
@@ -37,6 +65,14 @@
               }
             }
           ]
+        },
+        "support_status": {
+          "type": "object",
+          "properties": {
+            "baseline": {
+              "$ref": "#/definitions/baseline_status_report"
+            }
+          }
         }
       },
       "required": [


### PR DESCRIPTION
This PR adds a demonstration of simplified support status data.

In the future, we'll generate support statuses from BCD (see also https://github.com/mdn/browser-compat-data/issues/18828) and potentially other sources, based on descriptions of what makes up a feature.

Yet we reside in the future's past, where we have not yet invented the generator. Even worse, we can't be sure of the precise schema that a consumer would be eager to consume—stymieing the effort to invent the future. So in the mean time, we'll fake it with a [Flintstoned](https://stackingthebricks.com/the-fine-art-of-flintstoning/) simplified support status. This will let us work with consumers as if simplified support statuses existed before they're invented.

![](https://media.giphy.com/media/umehzEQ4uJdfO/giphy.gif)

This PR adds:

* A schema definition for a "baseline" web platform feature status
* A baseline status report for the `cascade-layers` feature, showing what the data looks like for a baseline feature
* A baseline status report for the `container-queries` feature, showing what the data looks like for a non-baseline feature
* A little bit of code to pave the way for the future
