### PR TITLE
Add use counters for WebVTT

### DIFF
--- a/feature-group-definitions/webvtt.yml
+++ b/feature-group-definitions/webvtt.yml
@@ -1,2 +1,6 @@
 spec: https://w3c.github.io/webvtt/
 caniuse: webvtt
+usage_stats:
+- https://chromestatus.com/metrics/feature/timeline/popularity/409
+- https://chromestatus.com/metrics/feature/timeline/popularity/410
+- https://chromestatus.com/metrics/feature/timeline/popularity/2891


### PR DESCRIPTION
VTTCue is for any VTTCue creation, whether from the JS constructor or
the WebVTT parser.

VTTCueParser is for the creation of a WebVTT parser for a `<track>`
element.

VTTCueRender is for when a cue is actually displayed, which would be
on top of a playing `<video>`.
