### PR TITLE
Add compat features for masonry and subgrid

### DIFF
--- a/feature-group-definitions/masonry.yml
+++ b/feature-group-definitions/masonry.yml
@@ -1,0 +1,7 @@
+spec: https://drafts.csswg.org/css-grid-3/
+compat_features:
+  - css.properties.align-tracks
+  - css.properties.grid-column-rows.masonry
+  - css.properties.grid-template-rows.masonry
+  - css.properties.justify-tracks
+  - css.properties.masonry-auto-flow

--- a/feature-group-definitions/subgrid.yml
+++ b/feature-group-definitions/subgrid.yml
@@ -1,2 +1,5 @@
 spec: https://drafts.csswg.org/css-grid-2/#subgrids
 caniuse: css-subgrid
+compat_features:
+  - css.properties.grid-template-columns.subgrid
+  - css.properties.grid-template-rows.subgrid


### PR DESCRIPTION
This is a follow up to https://github.com/web-platform-dx/feature-set/pull/78. It adds a group for `masonry` and adds compat data for both it and `subgrid`.

A natural follow up to this would be to introduce a structured way of describing the relationship between these features (i.e., that "classical" grid, subgrid, and masonry are each members of a common omnibus grid group).

cc: @captainbrosset