### PR TITLE
Fix formatting test

### DIFF
--- a/feature-group-definitions/webvtt.yml
+++ b/feature-group-definitions/webvtt.yml
@@ -1,6 +1,6 @@
 spec: https://w3c.github.io/webvtt/
 caniuse: webvtt
 usage_stats:
-- https://chromestatus.com/metrics/feature/timeline/popularity/409
-- https://chromestatus.com/metrics/feature/timeline/popularity/410
-- https://chromestatus.com/metrics/feature/timeline/popularity/2891
+  - https://chromestatus.com/metrics/feature/timeline/popularity/409
+  - https://chromestatus.com/metrics/feature/timeline/popularity/410
+  - https://chromestatus.com/metrics/feature/timeline/popularity/2891

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "caniuse-lite": "^1.0.30001469",
         "fast-json-stable-stringify": "^2.1.0",
         "fdir": "^6.0.1",
+        "prettier": "^2.8.7",
         "ts-json-schema-generator": "^1.2.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.5",
@@ -581,6 +582,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/punycode": {
@@ -1390,6 +1406,12 @@
       "dev": true,
       "optional": true,
       "peer": true
+    },
+    "prettier": {
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+      "dev": true
     },
     "punycode": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "ts-node scripts/build.ts",
     "generate-schema-defs": "ts-json-schema-generator --tsconfig ./tsconfig.json --type FeatureData --path ./index.ts --id defs --out ./schemas/defs.schema.json",
-    "test": "npm run test:caniuse -- --quiet && npm run test:schema && npm run test:specs && npm run format",
+    "test": "npm run test:caniuse -- --quiet && npm run test:schema && npm run test:specs && npm run test:format",
     "test:caniuse": "ts-node scripts/caniuse.ts",
     "test:schema": "ts-node scripts/schema.ts",
     "test:specs": "ts-node scripts/specs.ts",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "caniuse-lite": "^1.0.30001469",
     "fast-json-stable-stringify": "^2.1.0",
     "fdir": "^6.0.1",
+    "prettier": "^2.8.7",
     "ts-json-schema-generator": "^1.2.0",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5",


### PR DESCRIPTION
`npm test` was _applying_ the formatter, not checking whether prettier was satisfied. This PR fixes the mistake and applies YAML formatting to the one file currently out of compliance.