### PR TITLE
Allow more permissive spec URLs

### DIFF
--- a/feature-group-definitions/custom-elements.yml
+++ b/feature-group-definitions/custom-elements.yml
@@ -1,5 +1,4 @@
-# Tests don't allow the more specific https://html.spec.whatwg.org/multipage/custom-elements.html (yet)
-spec: https://html.spec.whatwg.org/multipage/
+spec: https://html.spec.whatwg.org/multipage/custom-elements.html
 caniuse: custom-elementsv1
 compat_features:
   - api.CustomElementRegistry

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -16,7 +16,7 @@ const defaultAllowlist: allowlistItem[] = [
 
 function isOK(url: URL, allowlist: allowlistItem[] = defaultAllowlist) {
     for (const specUrl of specUrls) {
-        if (specUrl.protocol !== url.protocol || specUrl.origin !== url.origin) {
+        if (specUrl.origin !== url.origin) {
             continue;
         }
         if (url.pathname.startsWith(specUrl.pathname)) {

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -1,18 +1,37 @@
+import assert from "node:assert/strict";
+
 import webSpecs from 'web-specs' assert { type: 'json' };
 
 import features from '../index.js';
 
-const specUrls = new Set(webSpecs.map(spec => spec.nightly.url));
+const specUrls = webSpecs.map(spec => new URL(spec.nightly.url));
+
+function isOK(url: URL) {
+    for (const specUrl of specUrls) {
+        if (specUrl.protocol !== url.protocol || specUrl.origin !== url.origin) {
+            continue;
+        }
+        if (url.pathname.startsWith(specUrl.pathname)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function testIsOK() {
+    assert.ok(isOK(new URL("https://tc39.es/ecma262/multipage/")));
+    assert.ok(isOK(new URL("https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at")));
+    assert.ok(!isOK(new URL("https://typo.csswg.org/css-anchor-position-1/#anchoring")));
+};
+testIsOK();
 
 let checked = 0;
 let errors = 0;
 
 for (const [id, data] of Object.entries(features)) {
     const url = new URL(data.spec);
-    // Remove any #fragment from end of URL.
-    url.hash = '';
-    if (!specUrls.has(url.toString())) {
-        console.error(`URL for ${id} not in web-specs: ${url}`);
+    if (!isOK(url)) {
+        console.error(`URL for ${id} not in web-specs: ${url.toString()}`);
         errors++;
     }
     checked++;

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -4,7 +4,12 @@ import webSpecs from 'web-specs' assert { type: 'json' };
 
 import features from '../index.js';
 
-const specUrls = webSpecs.map(spec => new URL(spec.nightly.url));
+const specUrls: URL[] = webSpecs.flatMap(spec => {
+    return [
+        new URL(spec.nightly.url),
+        ...(spec.nightly.pages ?? []).map(page => new URL(page))
+    ]
+});
 
 type allowlistItem = [url: string, message: string];
 const defaultAllowlist: allowlistItem[] = [
@@ -16,14 +21,8 @@ const defaultAllowlist: allowlistItem[] = [
 
 function isOK(url: URL, allowlist: allowlistItem[] = defaultAllowlist) {
     for (const specUrl of specUrls) {
-        if (specUrl.origin !== url.origin) {
-            continue;
-        }
-        if (specUrl.pathname === url.pathname) {
+        if (specUrl.origin === url.origin && specUrl.pathname === url.pathname) {
             // that is, specUrl and url are the same, with the exception of the hash or query (`search`) string
-            return true;
-        }
-        if (specUrl.pathname.includes("/multipage/") && url.pathname.startsWith(specUrl.pathname)) {
             return true;
         }
     }
@@ -34,6 +33,7 @@ function isOK(url: URL, allowlist: allowlistItem[] = defaultAllowlist) {
             return true;
         }
     }
+
     return false;
 }
 

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -6,15 +6,15 @@ import features from '../index.js';
 
 const specUrls = webSpecs.map(spec => new URL(spec.nightly.url));
 
-type exception = [url: string, message: string];
-const exceptions: exception[] = [
+type allowlistItem = [url: string, message: string];
+const defaultAllowlist: allowlistItem[] = [
     [
         "https://wicg.github.io/navigation-api/",
         "This spec is moving to WHATWG HTML. Remove this exception when https://github.com/whatwg/html/pull/8502 merges."
     ],
 ];
 
-function isOK(url: URL, allowlist: exception[] = exceptions) {
+function isOK(url: URL, allowlist: allowlistItem[] = defaultAllowlist) {
     for (const specUrl of specUrls) {
         if (specUrl.protocol !== url.protocol || specUrl.origin !== url.origin) {
             continue;

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -19,7 +19,11 @@ function isOK(url: URL, allowlist: allowlistItem[] = defaultAllowlist) {
         if (specUrl.origin !== url.origin) {
             continue;
         }
-        if (url.pathname.startsWith(specUrl.pathname)) {
+        if (specUrl.pathname === url.pathname) {
+            // that is, specUrl and url are the same, with the exception of the hash or query (`search`) string
+            return true;
+        }
+        if (specUrl.pathname.includes("/multipage") && url.pathname.startsWith(specUrl.pathname)) {
             return true;
         }
     }
@@ -37,6 +41,7 @@ function testIsOK() {
     assert.ok(isOK(new URL("https://tc39.es/ecma262/multipage/")));
     assert.ok(isOK(new URL("https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at")));
     assert.ok(!isOK(new URL("https://typo.csswg.org/css-anchor-position-1/#anchoring")));
+    assert.ok(!isOK(new URL("https://w3c.github.io/gamepad/extensions.htmltypo")))
     // Skip noisy test
     // assert.ok(isOK(new URL("https://www.example.com/"), [["https://www.example.com/", "Remove this exception when…"]]));
 };

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -23,7 +23,7 @@ function isOK(url: URL, allowlist: allowlistItem[] = defaultAllowlist) {
             // that is, specUrl and url are the same, with the exception of the hash or query (`search`) string
             return true;
         }
-        if (specUrl.pathname.includes("/multipage") && url.pathname.startsWith(specUrl.pathname)) {
+        if (specUrl.pathname.includes("/multipage/") && url.pathname.startsWith(specUrl.pathname)) {
             return true;
         }
     }

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -6,12 +6,27 @@ import features from '../index.js';
 
 const specUrls = webSpecs.map(spec => new URL(spec.nightly.url));
 
-function isOK(url: URL) {
+type exception = [url: string, message: string];
+const exceptions: exception[] = [
+    [
+        "https://wicg.github.io/navigation-api/",
+        "This spec is moving to WHATWG HTML. Remove this exception when https://github.com/whatwg/html/pull/8502 merges."
+    ],
+];
+
+function isOK(url: URL, allowlist: exception[] = exceptions) {
     for (const specUrl of specUrls) {
         if (specUrl.protocol !== url.protocol || specUrl.origin !== url.origin) {
             continue;
         }
         if (url.pathname.startsWith(specUrl.pathname)) {
+            return true;
+        }
+    }
+
+    for (const [specUrl, message] of allowlist) {
+        if (specUrl === url.toString()) {
+            console.warn(`${specUrl}: ${message}`);
             return true;
         }
     }
@@ -22,6 +37,8 @@ function testIsOK() {
     assert.ok(isOK(new URL("https://tc39.es/ecma262/multipage/")));
     assert.ok(isOK(new URL("https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at")));
     assert.ok(!isOK(new URL("https://typo.csswg.org/css-anchor-position-1/#anchoring")));
+    // Skip noisy test
+    // assert.ok(isOK(new URL("https://www.example.com/"), [["https://www.example.com/", "Remove this exception when…"]]));
 };
 testIsOK();
 


### PR DESCRIPTION
This changes the spec test to allow spec URL tests to pass when:

- A spec URL ~~starts with a URL~~ is known to `web-specs` (i.e., is one of `web-specs` `url` or `pages` strings, excluding hash fragments)
- A spec URL is specifically allowlisted

Merging this will unblock https://github.com/web-platform-dx/feature-set/pull/116.