### PR TITLE
Expose `compat_features` to consumers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -40,7 +40,7 @@ type usage_stats_url = string;
 // They're not part of the public schema (yet).
 // They'll be removed.
 const omittables = [
-    "compat_features"
+    // "compat_features"
 ]
 
 function scrub(data: FeatureData) {


### PR DESCRIPTION
This passe the BCD keys to the published package. Requested by @LeoMcA.