### PR TITLE
Use more specific spec URLs

### DIFF
--- a/feature-group-definitions/array-at.yml
+++ b/feature-group-definitions/array-at.yml
@@ -1,4 +1,3 @@
-spec: https://tc39.es/ecma262/multipage/
-# spec: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at
+spec: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.at
 compat_features:
   - javascript.builtins.Array.at

--- a/feature-group-definitions/array-flat.yml
+++ b/feature-group-definitions/array-flat.yml
@@ -1,6 +1,5 @@
 caniuse: array-flat
-spec: https://tc39.es/ecma262/multipage/
-# spec: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.flat
+spec: https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.flat
 compat_features:
   - javascript.builtins.Array.flat
   - javascript.builtins.Array.flatMap

--- a/feature-group-definitions/class-syntax.yml
+++ b/feature-group-definitions/class-syntax.yml
@@ -1,6 +1,5 @@
 caniuse: es6-class
-spec: https://tc39.es/ecma262/multipage/
-# spec: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions
+spec: https://tc39.es/ecma262/multipage/ecmascript-language-functions-and-classes.html#sec-class-definitions
 compat_features:
   - javascript.classes
   - javascript.classes.constructor


### PR DESCRIPTION
Now that we've got better spec URL validation, we can uncomment some URLs that would have previously failed.