### PR TITLE
Deduplicate `shadow-dom` compat features

### DIFF
--- a/feature-group-definitions/shadow-dom.yml
+++ b/feature-group-definitions/shadow-dom.yml
@@ -2,26 +2,14 @@ spec: https://dom.spec.whatwg.org/#shadow-trees
 caniuse: shadowdomv1
 compat_features:
   - api.Element.attachShadow
-  - api.Element.attachShadow
-  - api.Element.shadowRoot
   - api.Element.shadowRoot
   - api.Event.composed
-  - api.Event.composed
-  - api.Event.composedPath
   - api.Event.composedPath
   - api.HTMLSlotElement
-  - api.HTMLSlotElement
-  - api.HTMLSlotElement.slotchange_event
   - api.HTMLSlotElement.slotchange_event
   - api.Node.getRootNode
-  - api.Node.getRootNode
-  - api.Node.isConnected
   - api.Node.isConnected
   - api.ShadowRoot
-  - api.ShadowRoot
-  - api.ShadowRoot.host
   - api.ShadowRoot.host
   - api.ShadowRoot.mode
-  - api.ShadowRoot.mode
-  - html.elements.slot
   - html.elements.slot


### PR DESCRIPTION
I don't know what I did to cause all of the lines to be duplicated, but this fixes it.