### PR TITLE
Add flexbox compat features and status

### DIFF
--- a/feature-group-definitions/flexbox.yml
+++ b/feature-group-definitions/flexbox.yml
@@ -1,3 +1,59 @@
 spec: https://drafts.csswg.org/css-flexbox-1/
 caniuse: flexbox
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1692
+status:
+  is_baseline: true
+  since: "2020-10-20"
+  support:
+    chrome: "57"
+    edge: "79"
+    firefox: "81"
+    safari: "9"
+compat_features:
+  - css.properties.align-content.flex_context
+  # - css.properties.align-content.flex_context.center
+  # - css.properties.align-content.flex_context.flex-end
+  # - css.properties.align-content.flex_context.flex-start
+  # - css.properties.align-content.flex_context.space-around
+  # - css.properties.align-content.flex_context.space-between
+  - css.properties.align-content.flex_context.stretch
+  - css.properties.align-items.flex_context
+  - css.properties.align-items.flex_context.baseline
+  # - css.properties.align-items.flex_context.center
+  # - css.properties.align-items.flex_context.flex-end
+  # - css.properties.align-items.flex_context.flex-start
+  # - css.properties.align-items.flex_context.stretch
+  - css.properties.align-self.flex_context
+  # - css.properties.align-self.flex_context.auto
+  - css.properties.align-self.flex_context.baseline
+  # - css.properties.align-self.flex_context.center
+  # - css.properties.align-self.flex_context.flex-end
+  # - css.properties.align-self.flex_context.flex-start
+  - css.properties.align-self.flex_context.stretch
+  - css.properties.display.flex
+  - css.properties.display.inline-flex
+  - css.properties.flex
+  - css.properties.flex-basis
+  - css.properties.flex-basis.auto
+  - css.properties.flex-basis.max-content
+  - css.properties.flex-basis.min-content
+  - css.properties.flex-direction
+  # - css.properties.flex-direction.column
+  # - css.properties.flex-direction.column-reverse
+  # - css.properties.flex-direction.row
+  # - css.properties.flex-direction.row-reverse
+  - css.properties.flex-flow
+  - css.properties.flex-grow
+  - css.properties.flex-shrink
+  - css.properties.flex-wrap
+  # - css.properties.flex-wrap.nowrap
+  # - css.properties.flex-wrap.wrap
+  # - css.properties.flex-wrap.wrap-reverse
+  - css.properties.justify-content.flex_context
+  # - css.properties.justify-content.flex_context.center
+  # - css.properties.justify-content.flex_context.flex-end
+  # - css.properties.justify-content.flex_context.flex-start
+  # - css.properties.justify-content.flex_context.space-around
+  # - css.properties.justify-content.flex_context.space-between
+  - css.properties.justify-content.flex_context.stretch
+  - css.properties.order


### PR DESCRIPTION
This adds features and simplified support status to `flexbox`. This is probably the first great example of messy data creating issues.

Some issues I encountered here:

- I skimmed through the flexbox spec and wrote a list of expected BCD features. I commented out the ones that don't exist in BCD. It's interesting to see what keys do and do not exist in BCD. The two exceptions I deleted outright were `css.properties.flex-basis.content` and `css.properties.flex-basis.fit-content`, which seem to be distinctly later additions. It's interesting to consider whether we ought to complete the "missing" subfeatures, or to do as BCD does: assume they're supported with the parent feature.

- The `{flex,grid}_context` pseudo-groups in BCD are quite challenging to deal with. I once opened https://github.com/mdn/browser-compat-data/issues/13804 to address this and it was "fixed" by adding more compat features, instead of fixing the muddled structure (e.g., `css.properties.align-content` contains a `__compat` object). But I still don't get what the data _really_ means: what could `css.properties.align-content` represent, independently of flexbox and grid? Are all of the subfeatures of `flex_context` exclusive to flexbox (since none appear beneath `grid_context`)?

- Firefox has lots of weird notes—something to do with multi-line flexbox—especially `css.properties.flex-direction`. Thankfully this is all in the rather distant past so it's not critical if we're off by even dozens of releases, but it's a good example of the kind of thing that would be very challenging to untangle for a more recent feature.