### PR TITLE
Allow package to be imported without type assertion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 index.json
+index.js

--- a/packages/web-features/README.md
+++ b/packages/web-features/README.md
@@ -9,5 +9,6 @@ npm install web-features
 ```
 
 ```js
-import webFeatures from 'web-features' assert { type: 'json' };
+import webFeatures from 'web-features';
+// import webFeatures from 'web-features/index.json' assert { type: 'json' }
 ```

--- a/packages/web-features/index.ts
+++ b/packages/web-features/index.ts
@@ -1,5 +1,5 @@
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const jsonPath = fileURLToPath(new URL("./index.json", import.meta.url));
 const features = JSON.parse(readFileSync(jsonPath, { encoding: "utf-8" }));

--- a/packages/web-features/index.ts
+++ b/packages/web-features/index.ts
@@ -1,0 +1,7 @@
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+
+const jsonPath = fileURLToPath(new URL("./index.json", import.meta.url));
+const features = JSON.parse(readFileSync(jsonPath, { encoding: "utf-8" }));
+
+export default features;

--- a/packages/web-features/package-lock.json
+++ b/packages/web-features/package-lock.json
@@ -1,0 +1,28 @@
+{
+  "name": "web-features",
+  "version": "0.3.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "web-features",
+      "version": "0.3.0",
+      "devDependencies": {
+        "typescript": "^5.0.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
+      "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=12.20"
+      }
+    }
+  }
+}

--- a/packages/web-features/package.json
+++ b/packages/web-features/package.json
@@ -6,5 +6,20 @@
     "type": "git",
     "url": "https://github.com/web-platform-dx/feature-set.git"
   },
-  "main": "index.json"
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./index.json": "./index.json"
+  },
+  "files": [
+    "index.js",
+    "index.json"
+  ],
+  "scripts": {
+    "prepare": "tsc"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.4"
+  }
 }

--- a/packages/web-features/tsconfig.json
+++ b/packages/web-features/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "target": "ES2016",
+    "module": "ESNext",
+  }
+}


### PR DESCRIPTION
This converts the `web-features` package into a regularly `import`-able module. Some consequences of the way I've done this:

- I don't know how to publish TS types today, but I assume that's something we might have an interest in later, so I made sure that the module is TypeScript from the start. This requires a little bit of new configuration (in the `package.json` and the addition of a `tsconfig.json`) to prevent `tsc` from spewing `.js` files everywhere.
- The package has two exports: `index.js` and `index.json`. By doing it this way, `import features from "web-features/index.json" assert { type: "json" }` is still possible. This also opens the door for additional exports (e.g., including the schema alongside the data).

If you wish to test this package locally:

1. Check out this branch.
2. From the root of the repo, run `npm run build`.
3. From `packages/web-features`, run `npm pack`. This makes a release tarball.
4. From elsewhere (i.e., in some directory with its own, independent `package.json`), run `npm install <path to web-features-0.3.0.tgz>`.
5. Try importing the package.

This fixes https://github.com/web-platform-dx/feature-set/issues/151.