### PR TITLE
`offscreen-canvas`: suppress baseline status (for now)

### DIFF
--- a/feature-group-definitions/offscreen-canvas.yml
+++ b/feature-group-definitions/offscreen-canvas.yml
@@ -1,14 +1,14 @@
 spec: https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface
 caniuse: offscreencanvas
 usage_stats: https://chromestatus.com/metrics/feature/timeline/popularity/1624
-status:
-  is_baseline: false
-  # since: future
-  support:
-    chrome: "80"
-    edge: "80"
-    firefox: "105"
-    safari: "16.4"
+# status:
+#   is_baseline: false
+#   # since: future
+#   support:
+#     chrome: "80"
+#     edge: "80"
+#     firefox: "105"
+#     safari: "16.4"
 compat_features:
   - api.HTMLCanvasElement.transferControlToOffscreen
   - api.OffscreenCanvas


### PR DESCRIPTION
We don't have baseline display assets or guidelines for "coming soon" features, so this hides the status until we've sorted that out. This is similar to the way we've handled `container-queries` and `grid-animation`.