### PR TITLE
Downgrade `@types/node` to match `.node-version` Node.js

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "devDependencies": {
         "@types/caniuse-lite": "^1.0.1",
-        "@types/node": "^18.16.3",
+        "@types/node": "^16.18.28",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "caniuse-lite": "^1.0.30001486",
@@ -23,6 +23,9 @@
         "winston": "^3.8.2",
         "yaml": "^2.2.2",
         "yargs": "^17.7.2"
+      },
+      "engines": {
+        "node": ">=16.18.0 <20"
       }
     },
     "node_modules/@colors/colors": {
@@ -119,9 +122,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
-      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
+      "version": "16.18.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.28.tgz",
+      "integrity": "sha512-SNMfiPqsiPoYfmyi+2qnDO4nZyMIOCab/CW+Slcml0lhIzkOizYzWtt/A7tgB3TSitd+YJKi8fSC2Cpm/VCp7A==",
       "dev": true
     },
     "node_modules/acorn": {
@@ -1055,9 +1058,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.16.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.3.tgz",
-      "integrity": "sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==",
+      "version": "16.18.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.28.tgz",
+      "integrity": "sha512-SNMfiPqsiPoYfmyi+2qnDO4nZyMIOCab/CW+Slcml0lhIzkOizYzWtt/A7tgB3TSitd+YJKi8fSC2Cpm/VCp7A==",
       "dev": true
     },
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   },
   "type": "module",
   "main": "index.ts",
+  "engines": {
+    "node": ">=16.18.0"
+  },
   "scripts": {
     "build": "ts-node scripts/build.ts",
     "generate-schema-defs": "ts-json-schema-generator --tsconfig ./tsconfig.json --type FeatureData --path ./index.ts --id defs --out ./schemas/defs.schema.json",
@@ -21,7 +24,7 @@
   },
   "devDependencies": {
     "@types/caniuse-lite": "^1.0.1",
-    "@types/node": "^18.16.3",
+    "@types/node": "^16.18.28",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "caniuse-lite": "^1.0.30001486",


### PR DESCRIPTION
This PR:

* Aligns `@types/node` and `package.json` with `.node-version`
* Tells Dependabot to stop upgrade `@types/node` by major version

Closes https://github.com/web-platform-dx/feature-set/pull/170.