### PR TITLE
Update Navigation API URL (and remove exception)

### DIFF
--- a/feature-group-definitions/navigation.yml
+++ b/feature-group-definitions/navigation.yml
@@ -1,1 +1,1 @@
-spec: https://wicg.github.io/navigation-api/
+spec: https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api

--- a/scripts/specs.ts
+++ b/scripts/specs.ts
@@ -13,10 +13,10 @@ const specUrls: URL[] = webSpecs.flatMap(spec => {
 
 type allowlistItem = [url: string, message: string];
 const defaultAllowlist: allowlistItem[] = [
-    [
-        "https://wicg.github.io/navigation-api/",
-        "This spec is moving to WHATWG HTML. Remove this exception when https://github.com/whatwg/html/pull/8502 merges."
-    ],
+    // [
+    //     "https://example.com/spec/",
+    //     "This spec is allowed because…. Remove this exception when https://example.com/org/repo/pull/1234 merges."
+    // ]
 ];
 
 function isOK(url: URL, allowlist: allowlistItem[] = defaultAllowlist) {


### PR DESCRIPTION
https://github.com/whatwg/html/pull/8502 merged a few weeks ago, so we can now point to the real spec instead of the page linking the work-in-progress pull request.