### PR TITLE
Add motion path feature

### DIFF
--- a/feature-group-definitions/motion-path.yml
+++ b/feature-group-definitions/motion-path.yml
@@ -1,0 +1,14 @@
+spec: https://drafts.fxtf.org/motion-1/
+caniuse: css-motion-paths
+compat_features:
+  - css.properties.offset-anchor
+  - css.properties.offset-distance
+  - css.properties.offset-path
+  - css.properties.offset-path.basic-shape
+  - css.properties.offset-path.coord-box
+  - css.properties.offset-path.path
+  - css.properties.offset-path.ray
+  - css.properties.offset-position
+  - css.properties.offset-position.normal
+  - css.properties.offset-rotate
+  - css.properties.offset


### PR DESCRIPTION
Corresponds to https://caniuse.com/css-motion-paths

I think we might need an "also known as" field for this kind of thing. I wonder if this name will stick, long-term, without it being the name of a property directly.

<details>
<summary>This is a new feature. Expand for ideas for reviewing it.</summary>

- Is this a recognizable web feature to web developers? (caniuse features are often made by request, so it's likely, but let's double check our work here.)
- Is this a reasonable identifier for the feature?
- Does this have a reasonable spec link?
- Does this have a reasonable caniuse reference?
- Are the [mdn/browser-compat-data](https://github.com/mdn/browser-compat-data) features plausible pieces of the feature as a whole?
- Are any pieces missing?
- Are any of the listed features later additions, part of a distinct sub feature, or otherwise excludable?

</details>